### PR TITLE
⬆️ UPGRADE: Autoupdate pre-commit config cookiecutter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: black
         language_version: python3
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.1.2 # Use the sha or tag you want to point at
+    rev: v2.2.0 # Use the sha or tag you want to point at
     hooks:
       - id: prettier
   - repo: https://gitlab.com/pycqa/flake8


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/s-weigand/cookiecutter-pypackage/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>pip install pre-commit</em></summary>

```Shell
Collecting pre-commit
  Downloading pre_commit-2.9.0-py2.py3-none-any.whl (184 kB)
Collecting cfgv>=2.0.0
  Downloading cfgv-3.2.0-py2.py3-none-any.whl (7.3 kB)
Collecting toml
  Downloading toml-0.10.2-py2.py3-none-any.whl (16 kB)
Collecting pyyaml>=5.1
  Downloading PyYAML-5.3.1.tar.gz (269 kB)
Collecting virtualenv>=20.0.8
  Downloading virtualenv-20.2.0-py2.py3-none-any.whl (4.9 MB)
Collecting nodeenv>=0.11.1
  Downloading nodeenv-1.5.0-py2.py3-none-any.whl (21 kB)
Collecting identify>=1.0.0
  Downloading identify-1.5.10-py2.py3-none-any.whl (97 kB)
Collecting filelock<4,>=3.0.0
  Downloading filelock-3.0.12-py3-none-any.whl (7.6 kB)
Collecting distlib<1,>=0.3.1
  Downloading distlib-0.3.1-py2.py3-none-any.whl (335 kB)
Collecting appdirs<2,>=1.4.3
  Downloading appdirs-1.4.4-py2.py3-none-any.whl (9.6 kB)
Collecting six<2,>=1.9.0
  Downloading six-1.15.0-py2.py3-none-any.whl (10 kB)
Using legacy 'setup.py install' for pyyaml, since package 'wheel' is not installed.
Installing collected packages: cfgv, toml, pyyaml, filelock, distlib, appdirs, six, virtualenv, nodeenv, identify, pre-commit
    Running setup.py install for pyyaml: started
    Running setup.py install for pyyaml: finished with status 'done'
Successfully installed appdirs-1.4.4 cfgv-3.2.0 distlib-0.3.1 filelock-3.0.12 identify-1.5.10 nodeenv-1.5.0 pre-commit-2.9.0 pyyaml-5.3.1 six-1.15.0 toml-0.10.2 virtualenv-20.2.0
```



</details>
<details>
<summary><em>pre-commit autoupdate || (exit 0);</em></summary>

```Shell
Updating https://github.com/pre-commit/pre-commit-hooks ... [INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
already up to date.
Updating https://github.com/python/black ... [INFO] Initializing environment for https://github.com/python/black.
already up to date.
Updating https://github.com/pre-commit/mirrors-prettier ... [INFO] Initializing environment for https://github.com/pre-commit/mirrors-prettier.
updating v2.1.2 -> v2.2.0.
Updating https://gitlab.com/pycqa/flake8 ... [INFO] Initializing environment for https://gitlab.com/pycqa/flake8.
already up to date.
Updating https://github.com/PyCQA/isort ... [INFO] Initializing environment for https://github.com/PyCQA/isort.
already up to date.
```



</details>
<details>
<summary><em>pre-commit run -a || (exit 0);</em></summary>

```Shell
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-prettier:prettier@2.2.0.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/python/black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/mirrors-prettier.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://gitlab.com/pycqa/flake8.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/PyCQA/isort.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
Fix End of Files.........................................................Passed
Trim Trailing Whitespace.................................................Passed
Debug Statements (Python)................................................Failed
- hook id: debug-statements
- exit code: 1

{{cookiecutter.project_slug}}/setup.py - Could not parse ast

	Traceback (most recent call last):
	  File "/home/runner/.cache/pre-commit/repooy21lrpv/py_env-python3.9/lib/python3.9/site-packages/pre_commit_hooks/debug_statement_hook.py", line 55, in check_file
	    ast_obj = ast.parse(f.read(), filename=filename)
	  File "/opt/hostedtoolcache/Python/3.9.0/x64/lib/python3.9/ast.py", line 50, in parse
	    return compile(source, filename, mode, flags,
	  File "{{cookiecutter.project_slug}}/setup.py", line 13
	    requirements = [{%- if cookiecutter.command_line_interface|lower == 'click' %}'Click>=7.0',{%- endif %} ]
	                     ^
	SyntaxError: invalid syntax
	

{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py - Could not parse ast

	Traceback (most recent call last):
	  File "/home/runner/.cache/pre-commit/repooy21lrpv/py_env-python3.9/lib/python3.9/site-packages/pre_commit_hooks/debug_statement_hook.py", line 55, in check_file
	    ast_obj = ast.parse(f.read(), filename=filename)
	  File "/opt/hostedtoolcache/Python/3.9.0/x64/lib/python3.9/ast.py", line 50, in parse
	    return compile(source, filename, mode, flags,
	  File "{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py", line 7
	    {%- if cookiecutter.command_line_interface|lower == 'click' %}
	     ^
	SyntaxError: invalid syntax
	

{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py - Could not parse ast

	Traceback (most recent call last):
	  File "/home/runner/.cache/pre-commit/repooy21lrpv/py_env-python3.9/lib/python3.9/site-packages/pre_commit_hooks/debug_statement_hook.py", line 55, in check_file
	    ast_obj = ast.parse(f.read(), filename=filename)
	  File "/opt/hostedtoolcache/Python/3.9.0/x64/lib/python3.9/ast.py", line 50, in parse
	    return compile(source, filename, mode, flags,
	  File "{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py", line 3
	    {%- if cookiecutter.command_line_interface|lower == 'argparse' %}
	     ^
	SyntaxError: invalid syntax
	

{{cookiecutter.project_slug}}/docs/conf.py - Could not parse ast

	Traceback (most recent call last):
	  File "/home/runner/.cache/pre-commit/repooy21lrpv/py_env-python3.9/lib/python3.9/site-packages/pre_commit_hooks/debug_statement_hook.py", line 55, in check_file
	    ast_obj = ast.parse(f.read(), filename=filename)
	  File "/opt/hostedtoolcache/Python/3.9.0/x64/lib/python3.9/ast.py", line 50, in parse
	    return compile(source, filename, mode, flags,
	  File "{{cookiecutter.project_slug}}/docs/conf.py", line 21
	    import {{ cookiecutter.project_slug }}
	           ^
	SyntaxError: invalid syntax

black....................................................................Failed
- hook id: black
- exit code: 123

error: cannot format /home/runner/work/cookiecutter-pypackage/cookiecutter-pypackage/{{cookiecutter.project_slug}}/docs/conf.py: Cannot parse: 21:7: import {{ cookiecutter.project_slug }}
error: cannot format /home/runner/work/cookiecutter-pypackage/cookiecutter-pypackage/{{cookiecutter.project_slug}}/setup.py: Cannot parse: 13:17: requirements = [{%- if cookiecutter.command_line_interface|lower == 'click' %}'Click>=7.0',{%- endif %} ]
error: cannot format /home/runner/work/cookiecutter-pypackage/cookiecutter-pypackage/{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py: Cannot parse: 7:1: {%- if cookiecutter.command_line_interface|lower == 'click' %}
error: cannot format /home/runner/work/cookiecutter-pypackage/cookiecutter-pypackage/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py: Cannot parse: 3:1: {%- if cookiecutter.command_line_interface|lower == 'argparse' %}
Oh no! 💥 💔 💥
8 files left unchanged, 4 files failed to reformat.

prettier.................................................................Passed
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

tests/test_bake_project.py:9:1: F401 'yaml' imported but unused
docs/conf.py:15:1: F401 'os' imported but unused
docs/conf.py:16:1: F401 'shlex' imported but unused
docs/conf.py:17:1: F401 'sys' imported but unused
docs/conf.py:215:5: E265 block comment should start with '# '
docs/conf.py:217:5: E265 block comment should start with '# '
docs/conf.py:219:5: E265 block comment should start with '# '
docs/conf.py:221:5: E265 block comment should start with '# '
{{cookiecutter.project_slug}}/setup.py:13:18: E228 missing whitespace around modulo operator
{{cookiecutter.project_slug}}/setup.py:13:18: E999 SyntaxError: invalid syntax
{{cookiecutter.project_slug}}/setup.py:13:59: E227 missing whitespace around bitwise or shift operator
{{cookiecutter.project_slug}}/setup.py:13:78: E225 missing whitespace around operator
{{cookiecutter.project_slug}}/setup.py:13:91: E231 missing whitespace after ','
{{cookiecutter.project_slug}}/setup.py:13:93: E228 missing whitespace around modulo operator
{{cookiecutter.project_slug}}/setup.py:13:100: E501 line too long (105 > 99 characters)
{{cookiecutter.project_slug}}/setup.py:13:103: E225 missing whitespace around operator
{{cookiecutter.project_slug}}/setup.py:13:104: E202 whitespace before ']'
{{cookiecutter.project_slug}}/setup.py:21:2: E228 missing whitespace around modulo operator
{{cookiecutter.project_slug}}/setup.py:26:100: E501 line too long (103 > 99 characters)
{{cookiecutter.project_slug}}/setup.py:27:4: E225 missing whitespace around operator
{{cookiecutter.project_slug}}/setup.py:36:10: E228 missing whitespace around modulo operator
{{cookiecutter.project_slug}}/setup.py:36:73: E225 missing whitespace around operator
{{cookiecutter.project_slug}}/setup.py:38:10: E228 missing whitespace around modulo operator
{{cookiecutter.project_slug}}/setup.py:38:20: E225 missing whitespace around operator
{{cookiecutter.project_slug}}/setup.py:47:6: E228 missing whitespace around modulo operator
{{cookiecutter.project_slug}}/setup.py:47:59: E227 missing whitespace around bitwise or shift operator
{{cookiecutter.project_slug}}/setup.py:47:67: E225 missing whitespace around operator
{{cookiecutter.project_slug}}/setup.py:53:6: E228 missing whitespace around modulo operator
{{cookiecutter.project_slug}}/setup.py:53:16: E225 missing whitespace around operator
{{cookiecutter.project_slug}}/setup.py:55:6: E228 missing whitespace around modulo operator
{{cookiecutter.project_slug}}/setup.py:55:69: E225 missing whitespace around operator
{{cookiecutter.project_slug}}/setup.py:57:6: E228 missing whitespace around modulo operator
{{cookiecutter.project_slug}}/setup.py:57:16: E225 missing whitespace around operator
{{cookiecutter.project_slug}}/setup.py:60:100: E501 line too long (110 > 99 characters)
{{cookiecutter.project_slug}}/setup.py:61:100: E501 line too long (118 > 99 characters)
{{cookiecutter.project_slug}}/setup.py:74:100: E501 line too long (100 > 99 characters)
{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py:7:2: E228 missing whitespace around modulo operator
{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py:7:2: E999 SyntaxError: invalid syntax
{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py:7:43: E227 missing whitespace around bitwise or shift operator
{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py:7:62: E225 missing whitespace around operator
{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py:8:1: E402 module level import not at top of file
{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py:10:2: E228 missing whitespace around modulo operator
{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py:10:12: E225 missing whitespace around operator
{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py:12:1: E402 module level import not at top of file
{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py:12:45: E201 whitespace after '{'
{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py:12:71: E202 whitespace before '}'
{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py:14:2: E228 missing whitespace around modulo operator
{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py:14:43: E227 missing whitespace around bitwise or shift operator
{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py:14:62: E225 missing whitespace around operator
{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py:15:1: E402 module level import not at top of file
{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py:17:2: E228 missing whitespace around modulo operator
{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py:17:12: E225 missing whitespace around operator
{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py:21:1: E303 too many blank lines (3)
{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py:35:1: E305 expected 2 blank lines after class or function definition, found 0
{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py:35:2: E228 missing whitespace around modulo operator
{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py:35:43: E227 missing whitespace around bitwise or shift operator
{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py:35:62: E225 missing whitespace around operator
{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py:47:1: E305 expected 2 blank lines after class or function definition, found 0
{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py:47:2: E228 missing whitespace around modulo operator
{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py:47:12: E225 missing whitespace around operator
{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py:3:2: E228 missing whitespace around modulo operator
{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py:3:2: E999 SyntaxError: invalid syntax
{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py:3:43: E227 missing whitespace around bitwise or shift operator
{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py:3:65: E225 missing whitespace around operator
{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py:4:1: E402 module level import not at top of file
{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py:6:2: E228 missing whitespace around modulo operator
{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py:6:12: E225 missing whitespace around operator
{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py:7:1: E402 module level import not at top of file
{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py:9:2: E228 missing whitespace around modulo operator
{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py:9:43: E227 missing whitespace around bitwise or shift operator
{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py:9:62: E225 missing whitespace around operator
{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py:10:1: E402 module level import not at top of file
{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py:12:2: E228 missing whitespace around modulo operator
{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py:12:12: E225 missing whitespace around operator
{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py:14:2: E225 missing whitespace around operator
{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py:14:42: E227 missing whitespace around bitwise or shift operator
{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py:14:61: E225 missing whitespace around operator
{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py:15:1: E302 expected 2 blank lines, found 0
{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py:22:1: E305 expected 2 blank lines after class or function definition, found 0
{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py:22:2: E228 missing whitespace around modulo operator
{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py:22:12: E225 missing whitespace around operator
{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py:23:2: E228 missing whitespace around modulo operator
{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py:23:43: E227 missing whitespace around bitwise or shift operator
{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py:23:65: E225 missing whitespace around operator
{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py:24:1: E302 expected 2 blank lines, found 0
{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py:34:1: E305 expected 2 blank lines after class or function definition, found 0
{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py:34:2: E228 missing whitespace around modulo operator
{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/cli.py:34:12: E225 missing whitespace around operator
hooks/pre_gen_project.py:10:100: E501 line too long (113 > 99 characters)
{{cookiecutter.project_slug}}/docs/conf.py:21:8: E999 SyntaxError: invalid syntax
{{cookiecutter.project_slug}}/docs/conf.py:21:10: E201 whitespace after '{'
{{cookiecutter.project_slug}}/docs/conf.py:21:36: E202 whitespace before '}'
{{cookiecutter.project_slug}}/docs/conf.py:54:100: E501 line too long (106 > 99 characters)
{{cookiecutter.project_slug}}/docs/conf.py:55:100: E501 line too long (125 > 99 characters)
{{cookiecutter.project_slug}}/docs/conf.py:71:13: E201 whitespace after '{'
{{cookiecutter.project_slug}}/docs/conf.py:71:39: E202 whitespace before '}'
{{cookiecutter.project_slug}}/docs/conf.py:73:13: E201 whitespace after '{'
{{cookiecutter.project_slug}}/docs/conf.py:73:39: E202 whitespace before '}'

isort....................................................................Passed
```



</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- .pre-commit-config.yaml

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)