### PR TITLE
⬆️ UPGRADE: Autoupdate pre-commit config template

### DIFF
--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
       - id: absolufy-imports
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
 

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.4 # Use the sha or tag you want to point at
+    rev: v3.0.0-alpha.6 # Use the sha or tag you want to point at
     hooks:
       - id: prettier
 

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
         additional_dependencies: [flake8-docstrings]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.0.1
+    rev: v1.1.1
     hooks:
       - id: mypy
         exclude: "docs"
@@ -89,7 +89,7 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/myint/rstcheck
-    rev: "v6.1.1"
+    rev: "v6.1.2"
     hooks:
       - id: rstcheck
         additional_dependencies: [sphinx]
@@ -100,7 +100,7 @@ repos:
       - id: rst-backticks
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.2
+    rev: v2.2.4
     hooks:
       - id: codespell
         types: [file]

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/python/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
       - id: black
         language_version: python3

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
         additional_dependencies: [flake8-docstrings]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.0.0
+    rev: v1.0.1
     hooks:
       - id: mypy
         exclude: "docs"

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/python/black
-    rev: 23.1.0
+    rev: 23.3.0
     hooks:
       - id: black
         language_version: python3

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
         additional_dependencies: [flake8-docstrings]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.0.0
     hooks:
       - id: mypy
         exclude: "docs"


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/s-weigand/cookiecutter-pypackage/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>pip install pre-commit</em></summary>

```Shell
Collecting pre-commit
  Downloading pre_commit-3.0.2-py2.py3-none-any.whl (202 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 202.3/202.3 kB 4.5 MB/s eta 0:00:00
Collecting cfgv>=2.0.0
  Downloading cfgv-3.3.1-py2.py3-none-any.whl (7.3 kB)
Collecting identify>=1.0.0
  Downloading identify-2.5.16-py2.py3-none-any.whl (98 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 98.7/98.7 kB 10.5 MB/s eta 0:00:00
Collecting nodeenv>=0.11.1
  Downloading nodeenv-1.7.0-py2.py3-none-any.whl (21 kB)
Collecting pyyaml>=5.1
  Downloading PyYAML-6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (757 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 757.9/757.9 kB 10.6 MB/s eta 0:00:00
Collecting virtualenv>=20.10.0
  Downloading virtualenv-20.17.1-py3-none-any.whl (8.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 8.8/8.8 MB 23.1 MB/s eta 0:00:00
Requirement already satisfied: setuptools in /opt/hostedtoolcache/Python/3.11.1/x64/lib/python3.11/site-packages (from nodeenv>=0.11.1->pre-commit) (65.5.0)
Collecting distlib<1,>=0.3.6
  Downloading distlib-0.3.6-py2.py3-none-any.whl (468 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 468.5/468.5 kB 47.7 MB/s eta 0:00:00
Collecting filelock<4,>=3.4.1
  Downloading filelock-3.9.0-py3-none-any.whl (9.7 kB)
Collecting platformdirs<3,>=2.4
  Downloading platformdirs-2.6.2-py3-none-any.whl (14 kB)
Installing collected packages: distlib, pyyaml, platformdirs, nodeenv, identify, filelock, cfgv, virtualenv, pre-commit
Successfully installed cfgv-3.3.1 distlib-0.3.6 filelock-3.9.0 identify-2.5.16 nodeenv-1.7.0 platformdirs-2.6.2 pre-commit-3.0.2 pyyaml-6.0 virtualenv-20.17.1
```



</details>
<details>
<summary><em>pre-commit autoupdate || (exit 0);</em></summary>

```Shell
Updating https://github.com/pre-commit/pre-commit-hooks ... [INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
updating v4.3.0 -> v4.4.0.
Updating https://github.com/python/black ... [INFO] Initializing environment for https://github.com/python/black.
updating 22.10.0 -> 22.12.0.
Updating https://github.com/pre-commit/mirrors-prettier ... [INFO] Initializing environment for https://github.com/pre-commit/mirrors-prettier.
already up to date.
Updating https://gitlab.com/pycqa/flake8 ... An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/git', '-c', 'core.useBuiltinFSMonitor=false', 'fetch', 'origin', 'HEAD', '--tags')
return code: 128
stdout: (none)
stderr:
    fatal: could not read Username for 'https://gitlab.com': No such device or address
    
Check the log at /home/runner/.cache/pre-commit/pre-commit.log
```



</details>
<details>
<summary><em>pre-commit autoupdate -c \{\{cookiecutter.project_slug\}\}/.pre-commit-config.yaml || (exit 0);</em></summary>

```Shell
Updating https://github.com/pre-commit/pre-commit-hooks ... already up to date.
Updating https://github.com/asottile/pyupgrade ... [INFO] Initializing environment for https://github.com/asottile/pyupgrade.
already up to date.
Updating https://github.com/MarcoGorelli/absolufy-imports ... [INFO] Initializing environment for https://github.com/MarcoGorelli/absolufy-imports.
already up to date.
Updating https://github.com/PyCQA/isort ... [INFO] Initializing environment for https://github.com/PyCQA/isort.
updating 5.11.4 -> 5.12.0.
Updating https://github.com/python/black ... already up to date.
Updating https://github.com/pre-commit/mirrors-prettier ... already up to date.
Updating https://github.com/asottile/setup-cfg-fmt ... [INFO] Initializing environment for https://github.com/asottile/setup-cfg-fmt.
already up to date.
Updating https://github.com/pycqa/flake8 ... [INFO] Initializing environment for https://github.com/pycqa/flake8.
already up to date.
Updating https://github.com/asottile/yesqa ... [INFO] Initializing environment for https://github.com/asottile/yesqa.
already up to date.
Updating https://github.com/pre-commit/mirrors-mypy ... [INFO] Initializing environment for https://github.com/pre-commit/mirrors-mypy.
already up to date.
Updating https://github.com/PyCQA/pydocstyle ... [INFO] Initializing environment for https://github.com/PyCQA/pydocstyle.
already up to date.
Updating https://github.com/terrencepreilly/darglint ... [INFO] Initializing environment for https://github.com/terrencepreilly/darglint.
already up to date.
Updating https://github.com/econchick/interrogate ... [INFO] Initializing environment for https://github.com/econchick/interrogate.
already up to date.
Updating https://github.com/myint/rstcheck ... [INFO] Initializing environment for https://github.com/myint/rstcheck.
already up to date.
Updating https://github.com/pre-commit/pygrep-hooks ... [INFO] Initializing environment for https://github.com/pre-commit/pygrep-hooks.
already up to date.
Updating https://github.com/codespell-project/codespell ... [INFO] Initializing environment for https://github.com/codespell-project/codespell.
already up to date.
Updating https://github.com/econchick/interrogate ... already up to date.
```



</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- {{cookiecutter.project_slug}}/.pre-commit-config.yaml

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)