### PR TITLE
🩹 Use full workflow subfolder relative path in dependabot directory definition

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
       time: "04:00"
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
-    directory: "/{{cookiecutter.project_slug}}"
+    directory: "{{cookiecutter.project_slug}}/.github/workflows"
     schedule:
       interval: "weekly"
       time: "04:00"


### PR DESCRIPTION
This should allow dependabot to update workflows of the template

Ref.: https://github.com/dependabot/dependabot-core/issues/4899#issuecomment-1416029666