### PR TITLE
🚧 Only run CI on push to non bot branches

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/test.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/test.yml
@@ -1,5 +1,14 @@
 name: "Tests"
-on: [push, pull_request]
+
+on:
+  push:
+    tags:
+      - v**
+    branches-ignore:
+      - "dependabot/**"
+      - "sourcery/**"
+      - "pre-commit-ci-update-config"
+  pull_request:
 
 jobs:
   pre-commit:


### PR DESCRIPTION
This optimizes CI runs on push to not run on PR AND on push for bot branches