### PR TITLE
🚧🚇👌 Use dependabot groups and disable auto rebasing

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/dependabot.yml
+++ b/{{cookiecutter.project_slug}}/.github/dependabot.yml
@@ -4,10 +4,26 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      time: "04:00"
+      day: friday
+      time: "20:00"
+      timezone: Europe/Amsterdam
+    groups:
+      runtime-dependencies:
+        update-types:
+          - minor
+          - patch
+    rebase-strategy: "disabled"
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-      time: "04:00"
+      day: friday
+      time: "20:00"
+      timezone: Europe/Amsterdam
+    groups:
+      GH-Actions:
+        update-types:
+          - minor
+          - patch
+    rebase-strategy: "disabled"


### PR DESCRIPTION
This change will make dependabot updates more economical by:
- Grouping minor and patch updates
- Disabling autorebase