### PR TITLE
🧹 Drop py38 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Check out repo

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -2,8 +2,8 @@
 extend-exclude = ["venv", "docs/conf.py"]
 # Same as Black.
 line-length = 99
-# Assume Python 3.8.
-target-version = "py38"
+# Assume Python 3.9.
+target-version = "py39"
 # Enable using ruff with notebooks
 extend-include = ["*.ipynb"]
 

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -8,12 +8,13 @@ import sys
 from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
-from typing import Generator
 
 import pytest
 from cookiecutter.utils import rmtree
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
+
     from pytest_cookies.plugin import Cookies
     from pytest_cookies.plugin import Result
 

--- a/{{cookiecutter.project_slug}}/.github/workflows/test.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Check out repo

--- a/{{cookiecutter.project_slug}}/.ruff.toml
+++ b/{{cookiecutter.project_slug}}/.ruff.toml
@@ -6,8 +6,8 @@ extend-exclude = [
 # Same as Black.
 line-length = 99
 
-# Assume Python 3.8.
-target-version = "py38"
+# Assume Python 3.9.
+target-version = "py39"
 
 # Enable using ruff with notebooks
 extend-include = ["*.ipynb"]

--- a/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -104,7 +104,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.md.
-3. The pull request should work for Python 3.8, 3.9, 3.10, 3.11 and 3.12. Check
+3. The pull request should work for Python 3.9, 3.10, 3.11 and 3.12. Check
    {{ cookiecutter.git_host_url}}/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug_url }}/actions
    and make sure that the tests pass for all supported Python versions.
 

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -20,10 +20,10 @@ classifiers = [
   {%- endif %}
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
 ]
 
 {%- if cookiecutter.open_source_license in license_classifiers %}
@@ -45,7 +45,7 @@ name = "{{ cookiecutter.project_slug }}"
 description = "{{ cookiecutter.project_short_description }}"
 readme = "README.md"
 keywords = ["{{ cookiecutter.project_slug }}"]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dynamic = ["version"]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Python 3.8 will be EOL 31 Oct 2024 so new projects shouldn't support it